### PR TITLE
fix parsing

### DIFF
--- a/module.go
+++ b/module.go
@@ -52,7 +52,9 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if p.Provider.APIToken != "" {
 					return d.Err("API token already set")
 				}
-				p.Provider.APIToken = d.Val()
+				if d.NextArg() {
+					p.Provider.APIToken = d.Val()
+				}
 				if d.NextArg() {
 					return d.ArgErr()
 				}


### PR DESCRIPTION
while implementing the IONOS plugin I discovered that the parsing in the template has a bug for the case when the configuration is nested. 

Also see the IONOS plugin for some unit tests which could be useful here too.